### PR TITLE
Absolute path requests should be used as-is, not have request.path concatenated

### DIFF
--- a/src/__tests__/resolver_test.js
+++ b/src/__tests__/resolver_test.js
@@ -228,5 +228,38 @@ describe('ComponentResolverPlugin behavior', function() {
       resolveFn(request, done);
     });
   });
+
+  context('when absolute path is provided', function() {
+    var request = {
+      path: fixturesDir,
+      query: 'qwerty',
+      request: path.join(fixturesDir, 'dir_with_file')
+    };
+
+    beforeEach(function() {
+      emulateAndExtract();
+    });
+
+    it('evaluates the absolute path as-is', function(done) {
+      var cb = function() {};
+      var doResolve = sinon.spy(resolveContext, 'doResolve');
+      resolveFn(request, cb);
+
+      setTimeout(function() {
+        expect(doResolve).to.be.calledWithExactly(
+          'file',
+          sinon.match({
+            path: path.join(fixturesDir, 'dir_with_file'),
+            query: 'qwerty',
+            request: 'dir_with_file.jsx'
+          }),
+          cb
+        );
+
+        doResolve.restore();
+        done();
+      }, 10);
+    });
+  });
 });
 

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -10,7 +10,10 @@ var ENCLOSING_DIR_PATTERN = /(.+)\/.+$/;
 
 var getResolveComponent = function(exts) {
   return function(request, callback) {
-    var enclosingDirPath = path.join(request.path, request.request || '');
+    var enclosingDirPath = request.request || '';
+    if (enclosingDirPath.indexOf('/') !== 0) {
+      enclosingDirPath = path.join(request.path, enclosingDirPath);
+    }
     var captured = enclosingDirPath.match(COMPONENT_ID_PATTERN);
 
     // Ignore npm modules


### PR DESCRIPTION
This case comes up if someone provides an an [alias in their webpack config](https://webpack.github.io/docs/resolving.html#aliasing), which is an absolute path.

```js
{
    resolve: {
      alias: {
        'my-app': path.join(__dirname, 'src'),
        'react': require.resolve('react/addons')
      },
    },
```

Previously, in these cases the plugin would incorrectly prepend the `request.path` causing the it to be the wrong path and is not considered as a possible component.