### PR TITLE
Different regex for Windows

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -14,7 +14,7 @@ var ENCLOSING_DIR_PATTERN = WIN ? /(.+)\\.+$/ : /(.+)\/.+$/;
 var getResolveComponent = function(exts) {
   return function(request, callback) {
     var enclosingDirPath = request.request || '';
-    if (enclosingDirPath.indexOf('/') !== 0) {
+    if (!path.isAbsolute(enclosingDirPath)) {
       enclosingDirPath = path.join(request.path, enclosingDirPath);
     }
     var captured = enclosingDirPath.match(COMPONENT_ID_PATTERN);

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -4,7 +4,7 @@ var path = require('path');
 var WIN = /^win/.test(process.platform);
 
 // Captures component id (e.g 'feedback_form' from 'feedback/feedback_form').
-var COMPONENT_ID_PATTERN = /([^\/]+)$/;
+var COMPONENT_ID_PATTERN = WIN ? /([^\\]+)$/ : /([^\/]+)$/;
 
 // Captures enclosing dir
 // (e.g '_fixtures/dir_with_file_and_component' from

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,12 +1,15 @@
 var path = require('path');
 
+// Check if this is a windows runtime or not
+var WIN = /^win/.test(process.platform);
+
 // Captures component id (e.g 'feedback_form' from 'feedback/feedback_form').
 var COMPONENT_ID_PATTERN = /([^\/]+)$/;
 
 // Captures enclosing dir
 // (e.g '_fixtures/dir_with_file_and_component' from
 // '_fixtures/dir_with_file_and_component/component')
-var ENCLOSING_DIR_PATTERN = /(.+)\/.+$/;
+var ENCLOSING_DIR_PATTERN = WIN ? /(.+)\\.+$/ : /(.+)\/.+$/;
 
 var getResolveComponent = function(exts) {
   return function(request, callback) {


### PR DESCRIPTION
Rebased version of https://github.com/toptal/component-resolver-webpack/pull/1. I've added AppVeyor integration to ensure that all the tests are passing for Windows.